### PR TITLE
Remove type application "dot" like in `Array.<number>`

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "checkJs": true
+  }
+}

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -8,33 +8,40 @@ function combineNameAndType(nameString, typeString) {
     return nameString + separator + typeString;
 }
 
+/**
+ * @typedef {object} CatharsisType
+ * @property {string} name
+ * @property {string} type
+ * @property {CatharsisType} expression
+ * @property {CatharsisType} [key]
+ * @property {CatharsisType} [value]
+ * @property {CatharsisType[]} [applications]
+ * @property {CatharsisType[]} [elements]
+ * @property {CatharsisType[]} [fields]
+ * @property {boolean} [optional]
+ * @property {boolean} [nullable]
+ * @property {boolean} [repeatable]
+ */
+
 class Stringifier {
     constructor(options) {
         this._options = options || {};
         this._options.linkClass = this._options.linkClass || this._options.cssClass;
     }
 
+    /**
+     * @param {CatharsisType[]} applications - Array of type applications
+     * @returns {string}
+     */
     applications(applications) {
-        let result = '';
-        const strings = [];
-
         if (!applications) {
-            return result;
+            return '';
         }
-
-        for (let i = 0, l = applications.length; i < l; i++) {
-            strings.push(this.type(applications[i]));
-        }
-
-        if (this._options.htmlSafe) {
-            result = '.&lt;';
-        } else {
-            result = '.<';
-        }
-
-        result += `${strings.join(', ')}>`;
-
-        return result;
+        const inner = applications
+          .map(_ => this.type(_))
+          .join(', ');
+        const bracket = this._options.htmlSafe ? '&lt;' : '<';
+        return bracket + inner + '>';
     }
 
     elements(elements) {
@@ -77,6 +84,11 @@ class Stringifier {
         }
     }
 
+    /**
+     * 
+     * @param {boolean} optional 
+     * @returns 
+     */
     optional(optional) {
         if (optional === true) {
             return '=';
@@ -106,14 +118,26 @@ class Stringifier {
         return result ? `: ${this.type(result)}` : '';
     }
 
+    /**
+     * @param {CatharsisType} type 
+     * @returns {string}
+     */
     stringify(type) {
         return this.type(type);
     }
 
+    /**
+     * @param {CatharsisType} funcThis 
+     * @returns {string}
+     */
     this(funcThis) {
         return funcThis ? `this:${this.type(funcThis)}` : '';
     }
 
+    /**
+     * @param {CatharsisType} type 
+     * @returns {string}
+     */
     type(type) {
         let typeString = '';
 
@@ -158,12 +182,21 @@ class Stringifier {
         return typeString;
     }
 
+    /**
+     * 
+     * @param {CatharsisType} type 
+     * @returns {string}
+     */
     _record(type) {
         const fields = this._recordFields(type.fields);
 
         return `{${fields.join(', ')}}`;
     }
 
+    /**
+     * @param {CatharsisType[]} fields 
+     * @returns {any[]}
+     */
     _recordFields(fields) {
         let field;
         let keyAndValue;
@@ -186,7 +219,13 @@ class Stringifier {
         return result;
     }
 
-    // Adds optional, nullable, and repeatable modifiers if necessary.
+    /**
+     * Adds optional, nullable, and repeatable modifiers if necessary.
+     *
+     * @param {CatharsisType} type 
+     * @param {string} typeString 
+     * @returns {string}
+     */
     _addModifiers(type, typeString) {
         let combined;
 
@@ -203,6 +242,10 @@ class Stringifier {
         return repeatable + combined + optional;
     }
 
+    /**
+     * @param {string} nameString 
+     * @returns {string}
+     */
     _addLinks(nameString) {
         const href = this._getHrefForString(nameString);
         let link = nameString;


### PR DESCRIPTION
One step closer to a nicer output:

![image](https://user-images.githubusercontent.com/5236548/230727098-83cfc428-87ce-4a18-9489-d9db0bdbab81.png)

Without PR:

![image](https://user-images.githubusercontent.com/5236548/230727179-1a1a4ab9-b1b4-4e7a-8819-c98ab2095ca2.png)

The `Promise.<...>` is added by another npm package (jsdoc), which is work for later.

I also added JSDoc to make it a bit type safe + IntelliSense for potential future changes.